### PR TITLE
구글 소유확인용 html등록, openGraph 미리보기 이미지 사이즈 실제 사이즈로 변경

### DIFF
--- a/public/google27302cf77f128bc5.html
+++ b/public/google27302cf77f128bc5.html
@@ -1,0 +1,1 @@
+google-site-verification: google27302cf77f128bc5.html

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,8 +29,8 @@ export const metadata: Metadata = {
     images: [
       {
         url: "https://해월씨에스.com/images/logo.png",
-        width: 800,
-        height: 600,
+        width: 2050,
+        height: 540,
         alt: "해월씨에스 의원 로고",
       },
     ],


### PR DESCRIPTION
구글 소유확인용 html등록, openGraph 미리보기 이미지 사이즈 실제 사이즈로 변경